### PR TITLE
Fix for Safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,23 @@
 import teleformat from 'teleformat';
 
 export const inputHandler = (value, prevValue, selectionStart, countryCode) => {
-  const lengthDifference = value.length - prevValue.length;
-  const decorated = teleformat.decorate(value, countryCode);
+  const normalizedValue = value.trimLeft();
+
+  const lengthDifference = normalizedValue.length - prevValue.length;
+  const decorated = teleformat.decorate(normalizedValue, countryCode);
 
   if (decorated.international === '') {
-    return { value, selectionStart };
+    return {
+      normalizedValue,
+      selectionStart,
+      number: [],
+    };
   }
 
-  const afterCharacter = value[selectionStart - 1];
-  const isAfterLastCharacter = selectionStart === value.length;
+  const afterCharacter = normalizedValue[selectionStart - 1];
+  const isAfterLastCharacter = selectionStart === normalizedValue.length;
 
-  const nextValue = value.charAt(0) === '+' ? decorated.international : decorated.local;
+  const nextValue = normalizedValue.charAt(0) === '+' ? decorated.international : decorated.local;
 
   let nextSelectionStart = decorated.international.length;
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,10 @@ import MockElement from './mock-element';
 
 describe('teleformat-input', () => {
   describe('inputHandler', () => {
+    test('works for single +', () => {
+      expect(inputHandler('+', '', 1).value).toBe('+');
+    });
+
     test('doesnt decorate for unknown countries', () => {
       expect(inputHandler('+9991', '', 0).value).toBe('+9991');
     });


### PR DESCRIPTION
Input from Safari was occasionally getting whitespace characters
prepended to the string. This fix strips them out.